### PR TITLE
Tiny bug fix in splitPaneExtended example.

### DIFF
--- a/examples/core-examples/splitPaneExtended/splitPaneExtended.js
+++ b/examples/core-examples/splitPaneExtended/splitPaneExtended.js
@@ -33,7 +33,7 @@ uki(
 ).attachTo( window, '1000 600', {minSize: '600 0'} );
 
 // when we resize second split pane and hit border, try resizing first pane
-var top = uki('#top')[0];
+var topView = uki('#top')[0];
 uki('HSplitPane:eq(1)').bind('handleMove', function(e) { 
-    if (e.handlePosition > e.dragValue) top.handlePosition(top.handlePosition() - (e.handlePosition - e.dragValue) ).layout();
+    if (e.handlePosition > e.dragValue) topView.handlePosition(top.handlePosition() - (e.handlePosition - e.dragValue) ).layout();
 });


### PR DESCRIPTION
Setting "top" var in global space fails in Chrome ; It will default to window (which is not the expected behaviour).
